### PR TITLE
fix includes and remove tr1::unordered_map

### DIFF
--- a/src/common/dwarf/line_state_machine.h
+++ b/src/common/dwarf/line_state_machine.h
@@ -30,6 +30,8 @@
 #ifndef COMMON_DWARF_LINE_STATE_MACHINE_H__
 #define COMMON_DWARF_LINE_STATE_MACHINE_H__
 
+#include <stdint.h>
+
 namespace dwarf2reader {
 
 // This is the format of a DWARF2/3 line state machine that we process

--- a/src/common/md5.h
+++ b/src/common/md5.h
@@ -3,6 +3,7 @@
 #ifndef COMMON_MD5_H__
 #define COMMON_MD5_H__
 
+#include <stddef.h>
 #include <stdint.h>
 
 namespace google_breakpad {

--- a/src/common/unordered.h
+++ b/src/common/unordered.h
@@ -46,17 +46,11 @@ struct unordered_map : public __gnu_cxx::hash_map<T, U, H> {};
 template <class T, class H = __gnu_cxx::hash<T> >
 struct unordered_set : public __gnu_cxx::hash_set<T, H> {};
 
-#elif defined(_LIBCPP_VERSION)  // c++11
+#else
 #include <unordered_map>
 #include <unordered_set>
 using std::unordered_map;
 using std::unordered_set;
-
-#else  // Fallback to tr1::unordered
-#include <tr1/unordered_map>
-#include <tr1/unordered_set>
-using std::tr1::unordered_map;
-using std::tr1::unordered_set;
 #endif
 
 #endif  // COMMON_UNORDERED_H_

--- a/src/common/using_std_string.h
+++ b/src/common/using_std_string.h
@@ -55,6 +55,7 @@
 #ifdef HAS_GLOBAL_STRING
   typedef ::string google_breakpad_string;
 #else
+#include <string>
   using std::string;
   typedef std::string google_breakpad_string;
 #endif


### PR DESCRIPTION
_LIBCPP_VERSION doesn't reliably detect c++11.

Change-Id: I1adb4303269885e4a08648f049e14b244a2fde50
Reviewed-on: https://chromium-review.googlesource.com/c/breakpad/breakpad/+/2911693
Reviewed-by: Nelson Billing <nbilling@google.com>