### PR TITLE
add OWNERS settings

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,13 @@
+# Sorted alphabetically.
+# Please see README.md for contact info.
+
+ivanpe@chromium.org
+jperaza@chromium.org
+mark@chromium.org
+nbilling@google.com
+primiano@chromium.org
+saugustine@google.com
+rsesek@chromium.org
+ted@mielczarek.org
+thestig@chromium.org
+vapier@chromium.org


### PR DESCRIPTION
Since the entire Chromium GoB host is moving to enforce owners, make
sure we have settings in place ahead of time.

Change-Id: Ia8a52ff587a0b8f11f2b56caf9e283d05e2a822c
Reviewed-on: https://chromium-review.googlesource.com/c/breakpad/breakpad/+/2920608
Reviewed-by: Joshua Peraza <jperaza@chromium.org>
Reviewed-by: Lei Zhang <thestig@chromium.org>
Reviewed-by: Sterling Augustine <saugustine@google.com>
Reviewed-by: Robert Sesek <rsesek@chromium.org>
Reviewed-by: Mark Mentovai <mark@chromium.org>